### PR TITLE
Disable color-contrast for clinical-lowlight-theme wdio testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Disabled color-contrast axe-core rule for clinical-lowlight-theme wdio testing
 
 6.0.0 - (April 21, 2020)
 ----------

--- a/config/wdio/wdio.conf.js
+++ b/config/wdio/wdio.conf.js
@@ -94,6 +94,13 @@ const config = {
 
   axe: {
     inject: true,
+    options: {
+      rules: [
+        // The lowlight theme adheres to a non-default color contrast ratio and fails the default ratio check.
+        // The color-contrast ratio check must be disabled for lowlight theme testing.
+        { id: 'color-contrast', enabled: theme !== 'clinical-lowlight-theme' },
+      ],
+    },
   },
 
   terra: {

--- a/config/webpack/postcss/ThemePlugin.js
+++ b/config/webpack/postcss/ThemePlugin.js
@@ -8,6 +8,7 @@ const SUPPORTED_THEMES = [
   'orion-fusion-theme',
   'clinical-lowlight-theme',
   'cerner-clinical-theme',
+  'terra-default-theme',
 ];
 
 /**


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

This PR disables the axe-core color-contrast ratio rule for lowlight theme WDIO testing. The lowlight theme does not pass the default color contrast and follows a slightly different standard.

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

I logged an issue to axe-core about adjusting the rule settings. The initial feedback seems promising.

https://github.com/dequelabs/axe-core/issues/2175

I spent a few hours attempting to write tests for this, but mocking the process.env seems to be far more challenging than it sounds. I attempted to clear the cache per test run, but was not able to get anything working. The process.env is set the first time the file is imported and every import thereafter uses the cached values.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
