### PR TITLE
Added `TERRA_THEME_CONFIG` global to the webpack bundle.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Disabled color-contrast axe-core rule for clinical-lowlight-theme wdio testing
+* Added `TERRA_THEME_CONFIG` global to the webpack bundle.
 
 6.0.0 - (April 21, 2020)
 ----------

--- a/config/webpack/postcss/ThemePlugin.js
+++ b/config/webpack/postcss/ThemePlugin.js
@@ -1,9 +1,7 @@
-const fs = require('fs-extra');
-const path = require('path');
 const postcss = require('postcss');
 const removeCssModulesPseudoClasses = require('./_removeCssModulesPseudoClasses');
+const getThemeConfig = require('./_getThemeConfig');
 
-const CONFIG = 'terra-theme.config.js';
 const SUPPORTED_THEMES = [
   'orion-fusion-theme',
   'clinical-lowlight-theme',
@@ -17,16 +15,7 @@ const SUPPORTED_THEMES = [
  */
 module.exports = postcss.plugin('terra-theme-plugin', (config) => {
   // Retrieve theme config.
-  let themeConfig = {};
-  if (config) {
-    themeConfig = config;
-  } else {
-    const defaultConfig = path.resolve(process.cwd(), CONFIG);
-    if (fs.existsSync(defaultConfig)) {
-      // eslint-disable-next-line global-require, import/no-dynamic-require
-      themeConfig = require(defaultConfig);
-    }
-  }
+  const themeConfig = config || getThemeConfig();
 
   // Add the . to find the selector.
   const defaultThemeSelector = `.${themeConfig.theme}`;

--- a/config/webpack/postcss/_getThemeConfig.js
+++ b/config/webpack/postcss/_getThemeConfig.js
@@ -12,6 +12,4 @@ module.exports = () => {
     themeConfig = require(defaultConfig);
   }
   return themeConfig;
-}
-
-
+};

--- a/config/webpack/postcss/_getThemeConfig.js
+++ b/config/webpack/postcss/_getThemeConfig.js
@@ -1,0 +1,17 @@
+const fs = require('fs-extra');
+const path = require('path');
+
+const CONFIG = 'terra-theme.config.js';
+
+module.exports = () => {
+  let themeConfig = {};
+
+  const defaultConfig = path.resolve(process.cwd(), CONFIG);
+  if (fs.existsSync(defaultConfig)) {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    themeConfig = require(defaultConfig);
+  }
+  return themeConfig;
+}
+
+

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -13,6 +13,7 @@ const aggregateTranslations = require('terra-aggregate-translations');
 const ThemeAggregator = require('../../scripts/aggregate-themes/theme-aggregator');
 const getThemeWebpackPromise = require('./getThemeWebpackPromise');
 const ThemePlugin = require('./postcss/ThemePlugin');
+const getThemeConfig = require('./postcss/_getThemeConfig');
 
 const webpackConfig = (options, env, argv) => {
   const {
@@ -140,6 +141,7 @@ const webpackConfig = (options, env, argv) => {
       new webpack.DefinePlugin({
         CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(Date.now()).toISOString()),
         TERRA_AGGREGATED_LOCALES: JSON.stringify(aggregatedLocales),
+        TERRA_THEME_CONFIG: JSON.stringify(themeConfig),
       }),
     ],
     resolve: {
@@ -221,7 +223,7 @@ const defaultWebpackConfig = (env = {}, argv = {}) => {
   }
 
   const defaultTheme = process.env.THEME; // Flexes root theme for theme visual regression testing.
-  const themeConfig = defaultTheme ? { theme: defaultTheme } : null;
+  const themeConfig = defaultTheme ? { theme: defaultTheme } : getThemeConfig();
   let themeFile;
   if (!disableAggregateThemes) {
     // Set the default theme and disable scoped theme aggregation.

--- a/tests/jest/config/webpack/postcss/_getThemeConfig.test.js
+++ b/tests/jest/config/webpack/postcss/_getThemeConfig.test.js
@@ -1,0 +1,7 @@
+const getThemeConfig = require('../../../../../config/webpack/postcss/_getThemeConfig');
+
+describe('get Theme Config', () => {
+  it('returns empty if nothing can be found', () => {
+    expect(getThemeConfig()).toEqual({});
+  });
+});

--- a/tests/jest/config/webpack/webpack.config.test.js
+++ b/tests/jest/config/webpack/webpack.config.test.js
@@ -83,6 +83,7 @@ describe('webpack config', () => {
       const definePluginOptions = expect.objectContaining({
         CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(mockDate).toISOString()),
         TERRA_AGGREGATED_LOCALES: undefined,
+        TERRA_THEME_CONFIG: JSON.stringify({}),
       });
       expect(DefinePlugin).toBeCalledWith(definePluginOptions);
     });
@@ -177,6 +178,7 @@ describe('webpack config', () => {
       const definePluginOptions = expect.objectContaining({
         CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(mockDate).toISOString()),
         TERRA_AGGREGATED_LOCALES: undefined,
+        TERRA_THEME_CONFIG: JSON.stringify({}),
       });
       expect(DefinePlugin).toBeCalledWith(definePluginOptions);
 
@@ -227,6 +229,7 @@ describe('webpack config', () => {
       const expected = {
         CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(mockDate).toISOString()),
         TERRA_AGGREGATED_LOCALES: undefined,
+        TERRA_THEME_CONFIG: JSON.stringify({}),
       };
       expect(DefinePlugin).toBeCalledWith(expected);
     });
@@ -247,6 +250,7 @@ describe('webpack config', () => {
       const expected = {
         CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(mockDate).toISOString()),
         TERRA_AGGREGATED_LOCALES: JSON.stringify(aggregateOptions.locales),
+        TERRA_THEME_CONFIG: JSON.stringify({}),
       };
       expect(DefinePlugin).toBeCalledWith(expected);
     });

--- a/tests/jest/config/webpack/webpack.config.test.js
+++ b/tests/jest/config/webpack/webpack.config.test.js
@@ -20,11 +20,12 @@ const getThemeConfig = require('../../../../config/webpack/postcss/_getThemeConf
 
 const outputPath = expect.stringContaining('build');
 
+getThemeConfig.mockImplementation(() => ({ }));
+
 const mockDate = 1571689941977;
 
 describe('webpack config', () => {
   let config;
-  beforeEach(() => getThemeConfig.mockImplementation(() => ({ })));
   afterEach(() => aggregateTranslations.mockReset());
 
   describe('dev or prod config', () => {

--- a/tests/jest/config/webpack/webpack.config.test.js
+++ b/tests/jest/config/webpack/webpack.config.test.js
@@ -20,8 +20,6 @@ const getThemeConfig = require('../../../../config/webpack/postcss/_getThemeConf
 
 const outputPath = expect.stringContaining('build');
 
-getThemeConfig.mockImplementation(() => ({ }));
-
 const mockDate = 1571689941977;
 
 describe('webpack config', () => {

--- a/tests/jest/config/webpack/webpack.config.test.js
+++ b/tests/jest/config/webpack/webpack.config.test.js
@@ -5,6 +5,7 @@ jest.mock('mini-css-extract-plugin');
 jest.mock('clean-webpack-plugin');
 jest.mock('terser-webpack-plugin');
 jest.mock('webpack/lib/DefinePlugin');
+jest.mock('../../../../config/webpack/postcss/_getThemeConfig');
 
 // Import mocked components
 const PostCSSAssetsPlugin = require('postcss-assets-webpack-plugin');
@@ -15,13 +16,17 @@ const TerserPlugin = require('terser-webpack-plugin');
 const aggregateTranslations = require('terra-aggregate-translations');
 const DefinePlugin = require('webpack/lib/DefinePlugin');
 const webpackConfig = require('../../../../config/webpack/webpack.config');
+const getThemeConfig = require('../../../../config/webpack/postcss/_getThemeConfig');
 
 const outputPath = expect.stringContaining('build');
+
+getThemeConfig.mockImplementation(() => ({ }));
 
 const mockDate = 1571689941977;
 
 describe('webpack config', () => {
   let config;
+  beforeEach(() => getThemeConfig.mockImplementation(() => ({ })));
   afterEach(() => aggregateTranslations.mockReset());
 
   describe('dev or prod config', () => {
@@ -274,5 +279,22 @@ describe('webpack config', () => {
       };
       expect(config.devServer).toEqual(expect.objectContaining(expectedOuput));
     });
+  });
+
+  it('sets TERRA_THEME_CONFIG to the defined theme', () => {
+    getThemeConfig.mockImplementation(() => ({
+      theme: 'test-theme',
+    }));
+
+    config = webpackConfig({}, {});
+
+    const expected = {
+      CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(mockDate).toISOString()),
+      TERRA_AGGREGATED_LOCALES: undefined,
+      TERRA_THEME_CONFIG: JSON.stringify({
+        theme: 'test-theme',
+      }),
+    };
+    expect(DefinePlugin).toBeCalledWith(expected);
   });
 });


### PR DESCRIPTION
### Summary
This pr provides the root level terra-theme-config file as a global.

### Additional Details
This is so that terra-application can apply the appropriate theme name to the default/root theme.

Related PRs:
https://github.com/cerner/terra-framework/pull/1101
https://github.com/cerner/terra-application/pull/35

@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
