### PR TITLE
 Theme env and remove root pseudo selector when checking for theme name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* postcss theme plugin: remove :root pseduo selectors when checking for the theme selector.
+
+### Added
+* webpack config: add webpack env to allow overriding the theme.
 
 6.1.0 - (May 5, 2020)
 ----------

--- a/config/webpack/postcss/_removeCssModulesPseudoClasses.js
+++ b/config/webpack/postcss/_removeCssModulesPseudoClasses.js
@@ -4,7 +4,7 @@ const Tokenizer = require('css-selector-tokenizer');
  * Remove the css modules pseudo classes from a selector string.
  */
 module.exports = (selector) => {
-  const nodeNames = ['local', 'global'];
+  const nodeNames = ['local', 'global', 'root'];
   const sel = Tokenizer.parse(selector);
   sel.nodes.forEach(item => {
     // eslint-disable-next-line no-param-reassign

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -205,7 +205,7 @@ const defaultWebpackConfig = (env = {}, argv = {}) => {
     disableAggregateTranslations,
     disableHotReloading,
     disableAggregateThemes,
-    theme,
+    themeConfig: envThemeConfig,
   } = env;
 
   const staticOptions = {
@@ -227,8 +227,15 @@ const defaultWebpackConfig = (env = {}, argv = {}) => {
     resolveModules.unshift(path.resolve(rootPath, 'aggregated-translations'));
   }
 
-  const defaultTheme = process.env.THEME || theme; // Flexes root theme for theme visual regression testing.
-  const themeConfig = defaultTheme ? { theme: defaultTheme } : getThemeConfig();
+  const defaultTheme = process.env.THEME; // Flexes root theme for theme visual regression testing.
+  let themeConfig = {};
+  if (defaultTheme) {
+    themeConfig = { theme: defaultTheme };
+  } else if (envThemeConfig) {
+    themeConfig = envThemeConfig;
+  } else {
+    themeConfig = getThemeConfig();
+  }
   let themeFile;
   if (!disableAggregateThemes) {
     // Set the default theme and disable scoped theme aggregation.

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -201,7 +201,12 @@ const webpackConfig = (options, env, argv) => {
 };
 
 const defaultWebpackConfig = (env = {}, argv = {}) => {
-  const { disableAggregateTranslations, disableHotReloading, disableAggregateThemes } = env;
+  const {
+    disableAggregateTranslations,
+    disableHotReloading,
+    disableAggregateThemes,
+    theme,
+  } = env;
 
   const staticOptions = {
     ...disableHotReloading && {
@@ -222,7 +227,7 @@ const defaultWebpackConfig = (env = {}, argv = {}) => {
     resolveModules.unshift(path.resolve(rootPath, 'aggregated-translations'));
   }
 
-  const defaultTheme = process.env.THEME; // Flexes root theme for theme visual regression testing.
+  const defaultTheme = process.env.THEME || theme; // Flexes root theme for theme visual regression testing.
   const themeConfig = defaultTheme ? { theme: defaultTheme } : getThemeConfig();
   let themeFile;
   if (!disableAggregateThemes) {

--- a/tests/jest/config/webpack/postcss/_removeCssModulesPseudoClasses.test.js
+++ b/tests/jest/config/webpack/postcss/_removeCssModulesPseudoClasses.test.js
@@ -37,6 +37,12 @@ describe('Remove Css Modules Pseudo Classes', () => {
     expect(RemoveCssModulesPseudoClasses(selector)).toEqual(expectedSelector);
   });
 
+  it('removes before and after pseudo selectors', () => {
+    const selector = ':global .selector :root :local';
+    const expectedSelector = '.selector';
+    expect(RemoveCssModulesPseudoClasses(selector)).toEqual(expectedSelector);
+  });
+
   it('removes global', () => {
     const selector = ':global .selector';
     const expectedSelector = '.selector';

--- a/tests/jest/config/webpack/webpack.config.test.js
+++ b/tests/jest/config/webpack/webpack.config.test.js
@@ -296,4 +296,21 @@ describe('webpack config', () => {
     };
     expect(DefinePlugin).toBeCalledWith(expected);
   });
+
+  it('overrides theme config', () => {
+    getThemeConfig.mockImplementation(() => ({
+      theme: 'test-theme',
+    }));
+
+    config = webpackConfig({ theme: 'override-theme' }, {});
+
+    const expected = {
+      CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(mockDate).toISOString()),
+      TERRA_AGGREGATED_LOCALES: undefined,
+      TERRA_THEME_CONFIG: JSON.stringify({
+        theme: 'override-theme',
+      }),
+    };
+    expect(DefinePlugin).toBeCalledWith(expected);
+  });
 });

--- a/tests/jest/config/webpack/webpack.config.test.js
+++ b/tests/jest/config/webpack/webpack.config.test.js
@@ -302,7 +302,7 @@ describe('webpack config', () => {
       theme: 'test-theme',
     }));
 
-    config = webpackConfig({ theme: 'override-theme' }, {});
+    config = webpackConfig({ themeConfig: { theme: 'override-theme' } }, {});
 
     const expected = {
       CERNER_BUILD_TIMESTAMP: JSON.stringify(new Date(mockDate).toISOString()),


### PR DESCRIPTION
### Summary
A team has run into a situation where they want to generate two bundles via webpack for IE browsers, one with the default theme and one with the lowlight theme. The easiest way to achieve this, since our terra theme config only supports one bundle, is to open up an env variable to pass the theme config straight in via the env variables.

This PR also fixes a 'bug' with applying the theme css as the root.

Currently the postcss theme plugin will remove the cssmodule pseudo selectors `:local` and `:global`, then compare against the theme name selector exactly. This handles css that looks like this:
```scss
:local {
  .clinical-lowlight-theme {
    --theme-variable: #FFA500;
  }
}
```
The selector looks like this:
```
:local .clinical-lowlight-theme
```
and the `:local` pseudo selector will be removed to look like this:
```scss
.clinical-lowlight-theme
```
With the theme this team supplied, their scss looked like this after aggregate translations added the `.clinical-lowlight-theme` scope.
```scss
.clinical-lowlight-theme {
  :global {
    :root {
      --theme-variable: #FFA500;
    }
  }
}
```
The selector looks like this:
```
.clinical-lowlight-theme :global :root
```
and the `:global` pseudo selector will be removed to look like this:
```scss
.clinical-lowlight-theme :root 
```
Which would not match the theme selector name.

I considered several different ways to address this problem:

1. Remove all pseudo selectors
2. Return the first non pseudo selector
3. Remove only the :root pseudo selector

I landed on option 3 as the most targeted solution to resolve this issue without applying unintended css styles to root.

### Additional Details
I'd like to get this released on Tuesday. 

@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
