### PR TITLE
Limit result types of axe testing to violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Limited the full result types of axe testing to just `violations`. This should improve performance.
 
 6.4.0 - (June 30, 2020)
 ----------

--- a/src/wdio/services/TerraCommands/axe-command.js
+++ b/src/wdio/services/TerraCommands/axe-command.js
@@ -1,3 +1,4 @@
+
 /* global browser, axe */
 import fs from 'fs';
 
@@ -42,13 +43,15 @@ const runAxeTest = (axeRules) => {
   const rules = (formattedGlobalRules || axeRules) && { ...formattedGlobalRules, ...axeRules };
 
   /* Avoid arrow callback syntax as this function is injected into the browser */
-  const axeResult = browser.executeAsync((opts, done) => {
-    axe.run(document, opts, (error, result) => {
+  /* eslint-disable func-names, prefer-arrow-callback, object-shorthand */
+  const axeResult = browser.executeAsync(function (opts, done) {
+    axe.run(document, opts, function (error, result) {
       done({ error, result });
     });
   }, {
     rules, restoreScroll: true, runOnly: ['wcag2a', 'wcag2aa', 'wcag21aa', 'section508'], resultTypes: ['violations'],
   });
+  /* eslint-enable func-names, prefer-arrow-callback, object-shorthand */
 
   return axeResult.value;
 };

--- a/src/wdio/services/TerraCommands/axe-command.js
+++ b/src/wdio/services/TerraCommands/axe-command.js
@@ -1,4 +1,3 @@
-
 /* global browser, axe */
 import fs from 'fs';
 
@@ -43,13 +42,13 @@ const runAxeTest = (axeRules) => {
   const rules = (formattedGlobalRules || axeRules) && { ...formattedGlobalRules, ...axeRules };
 
   /* Avoid arrow callback syntax as this function is injected into the browser */
-  /* eslint-disable func-names, prefer-arrow-callback, object-shorthand */
-  const axeResult = browser.executeAsync(function (opts, done) {
-    axe.run(document, opts, function (error, result) {
+  const axeResult = browser.executeAsync((opts, done) => {
+    axe.run(document, opts, (error, result) => {
       done({ error, result });
     });
-  }, { rules, restoreScroll: true, runOnly: ['wcag2a', 'wcag2aa', 'wcag21aa', 'section508'] });
-  /* eslint-enable func-names, prefer-arrow-callback, object-shorthand */
+  }, {
+    rules, restoreScroll: true, runOnly: ['wcag2a', 'wcag2aa', 'wcag21aa', 'section508'], resultTypes: ['violations'],
+  });
 
   return axeResult.value;
 };


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

Limited the full result types of axe testing to just `violations`. This should improve performance and those are the ones that we care about from a testing perspective anyway.

I tested this internally and this change caused ie to go from blowing up due to a time out to passing.
