### PR TITLE
Remove Null value appended to the scoped section of `TERRA_THEME_CONFIG`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   * Updated to auto release from travis-ci.
   * Updated changelog formatting.
 
+* Fixed
+  * Removed Null value that aggregate translations was adding to the scoped field of the `TERRA_THEME_CONFIG` value defined via webpack.
+
 ## 6.7.0 - (August 4, 2020)
 
 * Changed

--- a/scripts/aggregate-themes/theme-aggregator.js
+++ b/scripts/aggregate-themes/theme-aggregator.js
@@ -71,9 +71,12 @@ class ThemeAggregator {
 
     const {
       theme: defaultThemeToAggregate,
-      scoped: scopedThemesToAggregate = [],
       aggregateDefaultThemeAsScopedTheme,
     } = options;
+
+    const scopedThemesToAggregate = [
+      ...options.scoped,
+    ];
 
     // The default theme is created by the post css theme plugin.
     if (aggregateDefaultThemeAsScopedTheme && !scopedThemesToAggregate.includes(defaultThemeToAggregate)) {

--- a/scripts/aggregate-themes/theme-aggregator.js
+++ b/scripts/aggregate-themes/theme-aggregator.js
@@ -75,7 +75,7 @@ class ThemeAggregator {
     } = options;
 
     const scopedThemesToAggregate = [
-      ...options.scoped,
+      ...(options?.scoped) ? options.scoped : [],
     ];
 
     // The default theme is created by the post css theme plugin.


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

Aggregate themes was indirectly adding a null (possibly a default theme name, in any case it was mutating it) value to the scoped section of the `TERRA_THEME_CONFIG` value that is defined via webpack.

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

This fix clones the array instead of appending to it.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
