### PR TITLE
Removed source map generation in loaders for prod.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* Changed
+  * Removed default source map generation in loaders for prod.
+
+* Added
+  * Added the generateLoaderSourceMaps env to re-enable source map generation for loaders on demand.
+
 ## 6.9.0 - (September 29, 2020)
 
 * Added

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -32,6 +32,7 @@ const webpackConfig = (options, env, argv) => {
   const filename = argv['output-filename'] || fileNameStategy;
   const outputPath = argv['output-path'] || path.join(rootPath, 'build');
   const publicPath = argv['output-public-path'] || '';
+  const sourceMap = env.generateLoaderSourceMaps || !production;
 
   const devConfig = {
     mode: 'development',
@@ -60,7 +61,6 @@ const webpackConfig = (options, env, argv) => {
               loader: MiniCssExtractPlugin.loader,
               options: {
                 hmr: !production, // only enable hot module reloading in development
-                sourceMap: true,
               },
             },
             {
@@ -70,7 +70,7 @@ const webpackConfig = (options, env, argv) => {
                   mode: 'global',
                   localIdentName: '[name]__[local]___[hash:base64:5]',
                 },
-                sourceMap: true,
+                sourceMap,
                 importLoaders: 2,
               },
             },
@@ -79,7 +79,7 @@ const webpackConfig = (options, env, argv) => {
               options: {
                 // Add unique ident to prevent the loader from searching for a postcss.config file. See: https://github.com/postcss/postcss-loader#plugins
                 ident: 'postcss',
-                sourceMap: true,
+                sourceMap,
                 plugins: [
                   ThemePlugin(themeConfig),
                   rtl(),
@@ -90,7 +90,7 @@ const webpackConfig = (options, env, argv) => {
             {
               loader: 'sass-loader',
               options: {
-                sourceMap: true,
+                sourceMap,
               },
             },
           ],
@@ -189,7 +189,7 @@ const webpackConfig = (options, env, argv) => {
         new TerserPlugin({
           cache: true,
           parallel: true,
-          sourceMap: true,
+          sourceMap,
           terserOptions: {
             compress: {
               typeofs: false,

--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -100,6 +100,10 @@ Terra's webpack configuration enables hot reloading by default in development mo
 tt-serve --env.disableHotReloading
 ```
 
+#### Generate Loader Source Maps
+
+Terra's webpack configuration disables source map generation by default in prod. Disable this behavior by passing `--env.generateLoaderSourceMaps`. This should be used in conjunction with setting the `devtool` webpack option. Caution, This may have a large performance impact, especially with large bundles.|
+
 #### Development vs Production
 The default webpack configuration is a function that will flex between production and development modes when passing the `-p` flag while compiling with webpack. See webpack's documentation on [configuration types](https://webpack.js.org/configuration/configuration-types/) for more information.
 


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

Removed source map generation in loaders for prod. Added the generate LoaderSourceMaps env to re-enable it on demand.

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
