### PR TITLE
Lock postcss-custom-properties Version to 9.1.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+ * Lock in postcss-custom-properties version to 9.1.1 to maintain the expected order that theme variables are applied.
+
 ## 6.10.0 - (October 20, 2020)
 
 * Changed

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "node-sass": "^4.11.0",
     "postcss": "^7.0.21",
     "postcss-assets-webpack-plugin": "^3.0.0",
-    "postcss-custom-properties": "^9.0.2",
+    "postcss-custom-properties": "9.1.1",
     "postcss-loader": "^3.0.0",
     "postcss-rtl": "^1.3.3",
     "raw-loader": "^3.0.0",


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
Lock in postcss-custom-properties version to 9.1.1 to maintain the expected order that theme variables are applied. In the 9.2.0 release, the importFrom order was changes to fix the expected order applied when providing additional css variables/values to the webpack bundle. Previously it applies importFrom then the code-imported vars. The new order applies importFrom after. This causes values from the old theme strategy to be applied over the most up to date values.

This was noticed in terra-notification-dialogs with the orion-fusion-theme applied where the border radius was 5 px when it should have been 0px. The latest theme value for border-radius is 0px; it was previously 5px.

### Additional Details
I logged an issue to the postcss-custom-properties repo: https://github.com/postcss/postcss-custom-properties/issues/231, but as @mjhenkes pointed out, this was like considered a bug fix from their perspective and this change restored expected functionality.

The latest theme strategy removes the need to aggregate themes all together, so this shouldn't be an issue when teams update to the new [@cerner/webpack-config-terra](https://github.com/cerner/terra-toolkit/tree/main/packages/webpack-config-terra) package.