### PR TITLE
Update Reporters to Use path.sep for Splitting File Paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## Unreleased
 
+* Fixed
+  * Update reporters to use `path.sep` to fix output errors seen when running on windows operating systems.
+
 ## 6.11.0 - (October 23, 2020)
 
 * Fixed
- * Lock in postcss-custom-properties version to 9.1.1 to maintain the expected order that theme variables are applied.
+  * Lock in postcss-custom-properties version to 9.1.1 to maintain the expected order that theme variables are applied.
 
- * Added
+* Added
   * Added deprecation warning to the following `Terra.it` helpers.
     * `Terra.it.isAccessible`
     * `Terra.it.matchesScreenshot`

--- a/reporters/jest/TerraVerboseReporter.js
+++ b/reporters/jest/TerraVerboseReporter.js
@@ -16,7 +16,7 @@ class TerraVerboseReporter extends VerboseReporter {
       endDate: '',
     };
     this.unformattedResult = {};
-    this.moduleName = process.cwd().split('/').pop();
+    this.moduleName = process.cwd().split(path.sep).pop();
     this.log = this.log.bind(this);
     this.ensureResultsDir = this.ensureResultsDir.bind(this);
     this.setTestModule = this.setTestModule.bind(this);
@@ -54,10 +54,10 @@ class TerraVerboseReporter extends VerboseReporter {
   }
 
   setTestModule(testLog) {
-    const index = testLog.lastIndexOf('packages/');
+    const index = testLog.lastIndexOf(`packages${path.sep}`);
     if (index > -1) {
-      const testFilePath = testLog.substring(index).split('/');
-      const moduleName = testFilePath && testFilePath[1] ? testFilePath[1] : process.cwd().split('/').pop();
+      const testFilePath = testLog.substring(index).split(path.sep);
+      const moduleName = testFilePath && testFilePath[1] ? testFilePath[1] : process.cwd().split(path.sep).pop();
       if (moduleName && moduleName !== this.moduleName) {
         this.moduleName = moduleName;
       }

--- a/reporters/wdio/TerraWDIOSpecReporter.js
+++ b/reporters/wdio/TerraWDIOSpecReporter.js
@@ -111,7 +111,7 @@ class TerraWDIOSpecReporter extends WDIOSpecReporter {
   * @return null
   */
   setTestModule(specsValue) {
-    const index = specsValue.lastIndexOf('packages');
+    const index = specsValue.lastIndexOf(`packages${path.sep}`);
     if (index > -1) {
       const testFilePath = specsValue.substring(index).split(path.sep);
       const moduleName = testFilePath && testFilePath[1] ? testFilePath[1] : process.cwd().split(path.sep).pop();

--- a/reporters/wdio/TerraWDIOSpecReporter.js
+++ b/reporters/wdio/TerraWDIOSpecReporter.js
@@ -22,7 +22,7 @@ class TerraWDIOSpecReporter extends WDIOSpecReporter {
       endDate: '',
     };
     this.fileName = '';
-    this.moduleName = process.cwd().split('/').pop();
+    this.moduleName = process.cwd().split(path.sep).pop();
 
     this.setResultsDir = this.setResultsDir.bind(this);
     this.hasResultsDir = this.hasResultsDir.bind(this);
@@ -111,10 +111,10 @@ class TerraWDIOSpecReporter extends WDIOSpecReporter {
   * @return null
   */
   setTestModule(specsValue) {
-    const index = specsValue.lastIndexOf('packages/');
+    const index = specsValue.lastIndexOf('packages');
     if (index > -1) {
-      const testFilePath = specsValue.substring(index).split('/');
-      const moduleName = testFilePath && testFilePath[1] ? testFilePath[1] : process.cwd().split('/').pop();
+      const testFilePath = specsValue.substring(index).split(path.sep);
+      const moduleName = testFilePath && testFilePath[1] ? testFilePath[1] : process.cwd().split(path.sep).pop();
       if (moduleName && moduleName !== this.moduleName) {
         this.moduleName = moduleName;
       }

--- a/tests/jest/TerraVerboseReporter.test.js
+++ b/tests/jest/TerraVerboseReporter.test.js
@@ -1,15 +1,18 @@
 import fs from 'fs';
+import path from 'path';
 import TerraVerboseReporter from '../../reporters/jest/TerraVerboseReporter';
 
 jest.mock('fs');
 
 describe('Jest File Reporter Testing', () => {
   let fsWriteSpy;
-  afterEach(() => {
-    fsWriteSpy.mockClear();
-  });
+
   beforeEach(() => {
     fsWriteSpy = jest.spyOn(fs, 'writeFileSync');
+  });
+
+  afterEach(() => {
+    fsWriteSpy.mockClear();
   });
 
   it('should have startdate property in the test results', () => {
@@ -37,6 +40,34 @@ describe('Jest File Reporter Testing', () => {
   it('should call setTestDirPath and include test in reporter filePath', () => {
     const verboseReporter = new TerraVerboseReporter({});
     expect(verboseReporter.filePath).toEqual(expect.stringContaining('test'));
+  });
+
+  describe('setTestModule', () => {
+    it('should set this.moduleName when root folder has package directory', () => {
+      const verboseReporter = new TerraVerboseReporter({});
+      verboseReporter.setTestModule('terra-toolkit-boneyard/packages/terra-clinical-header/tests/wdio/test-spec.js');
+      expect(verboseReporter.moduleName).toBe('terra-clinical-header');
+    });
+
+    it('should set this.moduleName when root folder has package directory and is windows path', () => {
+      const verboseReporter = new TerraVerboseReporter({});
+
+      const separator = path.sep;
+      path.sep = '\\';
+
+      expect(verboseReporter.moduleName).toEqual('terra-toolkit-boneyard');
+      verboseReporter.setTestModule('C:\\project\\packages\\my-package\\tests\\wdio\\test-spec.js');
+      expect(verboseReporter.moduleName).toEqual('my-package');
+
+      path.sep = separator;
+    });
+
+    it('does not updates moduleName if non mono-repo test file', () => {
+      const reporter = new TerraVerboseReporter({}, {});
+      expect(reporter.moduleName).toEqual('terra-toolkit-boneyard');
+      reporter.setTestModule('terra-toolkit-boneyard/tests/wdio/test-spec.js');
+      expect(reporter.moduleName).toEqual('terra-toolkit-boneyard');
+    });
   });
 
   it('should set this.moduleName when root folder has package directory', () => {

--- a/tests/jest/TerraWDIOSpecReporter.test.js
+++ b/tests/jest/TerraWDIOSpecReporter.test.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import TerraWDIOSpecReporter from '../../reporters/wdio/TerraWDIOSpecReporter';
 
 jest.mock('fs');
@@ -124,6 +125,18 @@ describe('TerraWDIOSpecReporter', () => {
       expect(reporter.moduleName).toEqual('terra-toolkit-boneyard');
       reporter.setTestModule('terra-toolkit-boneyard/packages/my-package/tests/wdio/test-spec.js');
       expect(reporter.moduleName).toEqual('my-package');
+    });
+
+    it('updates moduleName if mono-repo test file if windows path', () => {
+      const reporter = new TerraWDIOSpecReporter({}, {});
+      const separator = path.sep;
+      path.sep = '\\';
+
+      expect(reporter.moduleName).toEqual('terra-toolkit-boneyard');
+      reporter.setTestModule('C:\\project\\packages\\my-package\\tests\\wdio\\test-spec.js');
+      expect(reporter.moduleName).toEqual('my-package');
+
+      path.sep = separator;
     });
 
     it('does not updates moduleName if non mono-repo test file', () => {


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
Update to use `path.sep` in reporters to fix output errors seen when running on windows operating systems.

The error seen was:

```node
C:\project\type-js\node_modules\webdriverio\build\lib\utils\BaseReporter.js:351
                        throw _iteratorError;
                        ^

Error: ENOENT: no such file or directory, open 'C:\project\type-js\tests\wdio\reports\result-en-small-chrome-C:\project\type-js.json'
    at Object.fs.openSync (fs.js:646:18)
    at Object.fs.writeFileSync (fs.js:1299:33)
    at moduleKeys.forEach.key (C:\project\type-js\node_modules\terra-toolkit\reporters\wdio\TerraWDIOSpecReporter.js:180:12)
    at Array.forEach (<anonymous>)
    at TerraWDIOSpecReporter.printSummary (C:\project\type-js\node_modules\terra-toolkit\reporters\wdio\TerraWDIOSpecReporter.js:169:18)
    at TerraWDIOSpecReporter.printSuitesSummary (C:\project\type-js\node_modules\terra-toolkit\reporters\wdio\TerraWDIOSpecReporter.js:193:10)
    at TerraWDIOSpecReporter.<anonymous> (C:\project\type-js\node_modules\wdio-spec-reporter\build\reporter.js:115:18)
    at emitOne (events.js:116:13)
    at TerraWDIOSpecReporter.emit (events.js:211:7)
    at BaseReporter.handleEvent (C:\project\type js\node_modules\webdriverio\build\lib\utils\BaseReporter.js:339:35)
    at Launcher.endHandler (C:\project\type-js\node_modules\webdriverio\build\lib\launcher.js:716:28)
    at emitTwo (events.js:126:13)
    at ChildProcess.emit (events.js:214:7)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:198:12)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
```

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
