### PR TITLE
Fix error when spec data is undefined in the wdio details reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Fixed
   * Added back the TerraWDIOTestDetailsReporter
-  * Fixed TerraWDIOTestDetailsReporter as specData is undefined in some scenarios when viewport the user specifying don't match  the viewport in the spec file
+  * Fixed TerraWDIOTestDetailsReporter as specData is undefined in some scenarios when viewport the user specifying don't match the viewport in the spec file
   * Changed the result file names of TerraWDIOTestDetailsReporter form result-details to functional-test-details
 ## 6.14.1 - (March 3, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## Unreleased
 
 * Fixed
-  * added back the TerraWDIOTestDetailsReporter
-  * fixed issue in terra-core regarding TerraWDIOTestDetailsReporter
-  * changed the result file names of TerraWDIOTestDetailsReporter form result-details to functional-test-details
+  * Added back the TerraWDIOTestDetailsReporter
+  * Fixed TerraWDIOTestDetailsReporter as specData is undefined in some scenarios when viewport the user specifying don't match  the viewport in the spec file
+  * Changed the result file names of TerraWDIOTestDetailsReporter form result-details to functional-test-details
 ## 6.14.1 - (March 3, 2021)
 
 * Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Fixed
+  * added back the TerraWDIOTestDetailsReporter
+  * fixed issue in terra-core regarding TerraWDIOTestDetailsReporter
+  * changed the result file names of TerraWDIOTestDetailsReporter form result-details to functional-test-details
 ## 6.14.1 - (March 3, 2021)
 
 * Fixed

--- a/config/wdio/wdio.conf.js
+++ b/config/wdio/wdio.conf.js
@@ -10,6 +10,7 @@ const {
 } = require('../../lib/wdio/services/index');
 const visualRegressionConfig = require('./visualRegressionConf');
 const TerraWDIOSpecReporter = require('../../reporters/wdio/TerraWDIOSpecReporter');
+const TerraWDIOTestDetailsReporter = require('../../reporters/wdio/TerraWDIOTestDetailsReporter');
 
 /* Dynamically gets the host's IP, on macOS, when running wdio tests from a VM or behind a proxy. */
 /* Note: To keep the changes passive WDIO_EXTERNAL_HOST is given precedence */
@@ -127,7 +128,7 @@ const config = {
   reporterOptions: {
     outputDir: path.resolve(process.cwd(), 'tests', 'wdio', 'reports'),
   },
-  reporters: ['dot', TerraWDIOSpecReporter],
+  reporters: ['dot', TerraWDIOSpecReporter, TerraWDIOTestDetailsReporter],
   ...theme && { theme },
 };
 

--- a/reporters/wdio/TerraWDIOTestDetailsReporter.js
+++ b/reporters/wdio/TerraWDIOTestDetailsReporter.js
@@ -174,10 +174,7 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
    * @return null
    */
   runnerEnd(runner) {
-    const specData = this.moduleName ? this.specHashData[this.moduleName] : this.specHashData;
-    if (!specData) {
-      return;
-    }
+    const specData = this.moduleName && this.specHashData[this.moduleName] ? this.specHashData[this.moduleName] : this.specHashData;
     Object.values(specData).forEach((spec) => {
       const revSpecs = Object.values(spec);
       revSpecs.forEach((test, i) => {

--- a/reporters/wdio/TerraWDIOTestDetailsReporter.js
+++ b/reporters/wdio/TerraWDIOTestDetailsReporter.js
@@ -174,9 +174,7 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
    * @return null
    */
   runnerEnd(runner) {
-    const specData = this.moduleName
-      ? this.specHashData[this.moduleName]
-      : this.specHashData;
+    const specData = this.moduleName ? this.specHashData[this.moduleName] : this.specHashData;
     if (!specData) {
       return;
     }
@@ -324,9 +322,9 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
   // eslint-disable-next-line class-methods-use-this
   writeToFile(data, filePath) {
     try {
-      fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}`, {
-        flag: 'w+',
-      });
+      const json = `${JSON.stringify(data, null, 2)}`;
+      const options = { flag: 'w+' };
+      fs.writeFileSync(filePath, json, options);
     } catch (err) {
       Logger.error(err.message, { context: LOG_CONTEXT });
     }

--- a/reporters/wdio/TerraWDIOTestDetailsReporter.js
+++ b/reporters/wdio/TerraWDIOTestDetailsReporter.js
@@ -31,7 +31,7 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
     this.moduleName = '';
     this.setResultsDir.bind(this);
     this.hasResultsDir.bind(this);
-    this.writToFile.bind(this);
+    this.writeToFile.bind(this);
     this.setTestModule = this.setTestModule.bind(this);
     this.title = '';
     this.state = '';
@@ -214,7 +214,7 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
           `${this.fileName}.json`,
         );
         this.resultJsonObject.specs[this.moduleName] = revSpecs.shift();
-        this.writToFile(
+        this.writeToFile(
           this.resultJsonObject.specs[this.moduleName],
           filePathLocation,
         );
@@ -228,7 +228,7 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
         this.resultsDir,
         `${this.fileName}.json`,
       );
-      this.writToFile(this.resultJsonObject, filePathLocation);
+      this.writeToFile(this.resultJsonObject, filePathLocation);
     }
     this.screenshots = [];
     this.specHashData = {};
@@ -323,7 +323,7 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
    * @return null
    */
   // eslint-disable-next-line class-methods-use-this
-  writToFile(data, filePath) {
+  writeToFile(data, filePath) {
     try {
       fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}`, {
         flag: 'w+',

--- a/reporters/wdio/TerraWDIOTestDetailsReporter.js
+++ b/reporters/wdio/TerraWDIOTestDetailsReporter.js
@@ -173,13 +173,12 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
    * Format resultJsonObject based on parent and nest the tests
    * @return null
    */
-  /* eslint consistent-return: off */
   runnerEnd(runner) {
     const specData = this.moduleName
       ? this.specHashData[this.moduleName]
       : this.specHashData;
     if (!specData) {
-      return null;
+      return;
     }
     Object.values(specData).forEach((spec) => {
       const revSpecs = Object.values(spec);

--- a/reporters/wdio/TerraWDIOTestDetailsReporter.js
+++ b/reporters/wdio/TerraWDIOTestDetailsReporter.js
@@ -171,45 +171,46 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
    */
   runnerEnd(runner) {
     const specData = this.moduleName ? this.specHashData[this.moduleName] : this.specHashData;
-    Object.values(specData).forEach((spec) => {
-      const revSpecs = Object.values(spec);
-      revSpecs.forEach((test, i) => {
-        if (test.parent === test.title) {
-          const { title, parent, ...rest } = revSpecs[i];
-          revSpecs[i] = {
-            title,
-            spec: runner.specs[0],
-            ...rest,
-          };
-        }
-        if (test.parent !== test.title) {
-          const parentIndex = revSpecs.findIndex(
-            (item) => item.title === test.parent,
-          );
-
-          if (parentIndex > -1) {
-            if (!revSpecs[parentIndex].suites) {
-              revSpecs[parentIndex].suites = [];
-            }
-            revSpecs[parentIndex].suites.push(test);
-            // eslint-disable-next-line no-param-reassign
-            delete test.parent;
+    if (specData) {
+      Object.values(specData).forEach((spec) => {
+        const revSpecs = Object.values(spec);
+        revSpecs.forEach((test, i) => {
+          if (test.parent === test.title) {
+            const { title, parent, ...rest } = revSpecs[i];
+            revSpecs[i] = {
+              title,
+              spec: runner.specs[0],
+              ...rest,
+            };
           }
+          if (test.parent !== test.title) {
+            const parentIndex = revSpecs.findIndex(
+              (item) => item.title === test.parent,
+            );
+            if (parentIndex > -1) {
+              if (!revSpecs[parentIndex].suites) {
+                revSpecs[parentIndex].suites = [];
+              }
+              revSpecs[parentIndex].suites.push(test);
+              // eslint-disable-next-line no-param-reassign
+              delete test.parent;
+            }
+          }
+          // eslint-disable-next-line no-param-reassign
+          delete test.parent;
+        });
+        if (this.moduleName) {
+          const filePathLocation = path.join(
+            this.resultsDir,
+            `${this.fileName}.json`,
+          );
+          this.resultJsonObject.specs[this.moduleName] = revSpecs.shift();
+          this.writToFile(this.resultJsonObject.specs[this.moduleName], filePathLocation);
+        } else {
+          this.nonMonoRepoResult.push(revSpecs.shift());
         }
-        // eslint-disable-next-line no-param-reassign
-        delete test.parent;
       });
-      if (this.moduleName) {
-        const filePathLocation = path.join(
-          this.resultsDir,
-          `${this.fileName}.json`,
-        );
-        this.resultJsonObject.specs[this.moduleName] = revSpecs.shift();
-        this.writToFile(this.resultJsonObject.specs[this.moduleName], filePathLocation);
-      } else {
-        this.nonMonoRepoResult.push(revSpecs.shift());
-      }
-    });
+    }
     if (!this.moduleName) {
       this.resultJsonObject.specs = this.nonMonoRepoResult;
       const filePathLocation = path.join(
@@ -275,7 +276,7 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
    * @return null
    */
   fileNameCheck({ formFactor, locale, theme }, { browserName }, moduleName) {
-    const fileNameConf = ['result-details'];
+    const fileNameConf = ['functional-test-details'];
     if (moduleName) {
       fileNameConf.push(moduleName);
     }

--- a/reporters/wdio/TerraWDIOTestDetailsReporter.js
+++ b/reporters/wdio/TerraWDIOTestDetailsReporter.js
@@ -131,7 +131,11 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
   testEnd(test) {
     const { specHash, parent } = test;
     const { specHashData, moduleName } = this;
-    if (moduleName && specHashData[moduleName][specHash] && specHashData[moduleName][specHash][parent]) {
+    if (
+      moduleName
+      && specHashData[moduleName][specHash]
+      && specHashData[moduleName][specHash][parent]
+    ) {
       const { tests } = specHashData[moduleName][specHash][parent];
       if (this.state !== 'fail') {
         tests.push({
@@ -169,48 +173,55 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
    * Format resultJsonObject based on parent and nest the tests
    * @return null
    */
+  /* eslint consistent-return: off */
   runnerEnd(runner) {
-    const specData = this.moduleName ? this.specHashData[this.moduleName] : this.specHashData;
-    if (specData) {
-      Object.values(specData).forEach((spec) => {
-        const revSpecs = Object.values(spec);
-        revSpecs.forEach((test, i) => {
-          if (test.parent === test.title) {
-            const { title, parent, ...rest } = revSpecs[i];
-            revSpecs[i] = {
-              title,
-              spec: runner.specs[0],
-              ...rest,
-            };
-          }
-          if (test.parent !== test.title) {
-            const parentIndex = revSpecs.findIndex(
-              (item) => item.title === test.parent,
-            );
-            if (parentIndex > -1) {
-              if (!revSpecs[parentIndex].suites) {
-                revSpecs[parentIndex].suites = [];
-              }
-              revSpecs[parentIndex].suites.push(test);
-              // eslint-disable-next-line no-param-reassign
-              delete test.parent;
-            }
-          }
-          // eslint-disable-next-line no-param-reassign
-          delete test.parent;
-        });
-        if (this.moduleName) {
-          const filePathLocation = path.join(
-            this.resultsDir,
-            `${this.fileName}.json`,
-          );
-          this.resultJsonObject.specs[this.moduleName] = revSpecs.shift();
-          this.writToFile(this.resultJsonObject.specs[this.moduleName], filePathLocation);
-        } else {
-          this.nonMonoRepoResult.push(revSpecs.shift());
-        }
-      });
+    const specData = this.moduleName
+      ? this.specHashData[this.moduleName]
+      : this.specHashData;
+    if (!specData) {
+      return null;
     }
+    Object.values(specData).forEach((spec) => {
+      const revSpecs = Object.values(spec);
+      revSpecs.forEach((test, i) => {
+        if (test.parent === test.title) {
+          const { title, parent, ...rest } = revSpecs[i];
+          revSpecs[i] = {
+            title,
+            spec: runner.specs[0],
+            ...rest,
+          };
+        }
+        if (test.parent !== test.title) {
+          const parentIndex = revSpecs.findIndex(
+            (item) => item.title === test.parent,
+          );
+          if (parentIndex > -1) {
+            if (!revSpecs[parentIndex].suites) {
+              revSpecs[parentIndex].suites = [];
+            }
+            revSpecs[parentIndex].suites.push(test);
+            // eslint-disable-next-line no-param-reassign
+            delete test.parent;
+          }
+        }
+        // eslint-disable-next-line no-param-reassign
+        delete test.parent;
+      });
+      if (this.moduleName) {
+        const filePathLocation = path.join(
+          this.resultsDir,
+          `${this.fileName}.json`,
+        );
+        this.resultJsonObject.specs[this.moduleName] = revSpecs.shift();
+        this.writToFile(
+          this.resultJsonObject.specs[this.moduleName],
+          filePathLocation,
+        );
+      } else {
+        this.nonMonoRepoResult.push(revSpecs.shift());
+      }
+    });
     if (!this.moduleName) {
       this.resultJsonObject.specs = this.nonMonoRepoResult;
       const filePathLocation = path.join(
@@ -232,7 +243,9 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
     const index = specsValue.lastIndexOf('packages/');
     if (index > -1) {
       const testFilePath = specsValue.substring(index).split(path.sep);
-      const moduleName = testFilePath && testFilePath[1] ? testFilePath[1] : process.cwd().split(path.sep).pop();
+      const moduleName = testFilePath && testFilePath[1]
+        ? testFilePath[1]
+        : process.cwd().split(path.sep).pop();
       if (moduleName && moduleName !== this.moduleName) {
         this.moduleName = moduleName;
       }
@@ -312,11 +325,9 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
   // eslint-disable-next-line class-methods-use-this
   writToFile(data, filePath) {
     try {
-      fs.writeFileSync(
-        filePath,
-        `${JSON.stringify(data, null, 2)}`,
-        { flag: 'w+' },
-      );
+      fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}`, {
+        flag: 'w+',
+      });
     } catch (err) {
       Logger.error(err.message, { context: LOG_CONTEXT });
     }

--- a/tests/jest/TerraWDIOTestDetailsReporter.test.js
+++ b/tests/jest/TerraWDIOTestDetailsReporter.test.js
@@ -76,7 +76,7 @@ describe.only('TerraWDIOTestDetailsReporter', () => {
     it('sets default file name', () => {
       const reporter = new TerraWDIOTestDetailsReporter({}, {});
       reporter.fileNameCheck({ }, '');
-      expect(reporter.fileName).toEqual('result-details');
+      expect(reporter.fileName).toEqual('functional-test-details');
       expect(reporter.resultJsonObject).toHaveProperty('locale', '');
       expect(reporter.resultJsonObject).toHaveProperty('theme', '');
       expect(reporter.resultJsonObject).toHaveProperty('formFactor', '');
@@ -86,7 +86,7 @@ describe.only('TerraWDIOTestDetailsReporter', () => {
     it('sets file name with locale', () => {
       const reporter = new TerraWDIOTestDetailsReporter({}, {});
       reporter.fileNameCheck({ locale: 'en' }, '');
-      expect(reporter.fileName).toEqual('result-details-en');
+      expect(reporter.fileName).toEqual('functional-test-details-en');
       expect(reporter.resultJsonObject).toHaveProperty('locale', 'en');
       expect(reporter.resultJsonObject).toHaveProperty('theme', '');
       expect(reporter.resultJsonObject).toHaveProperty('formFactor', '');
@@ -96,7 +96,7 @@ describe.only('TerraWDIOTestDetailsReporter', () => {
     it('sets file name with locale and theme', () => {
       const reporter = new TerraWDIOTestDetailsReporter({}, {});
       reporter.fileNameCheck({ locale: 'en', theme: 'default' }, '');
-      expect(reporter.fileName).toEqual('result-details-en-default');
+      expect(reporter.fileName).toEqual('functional-test-details-en-default');
       expect(reporter.resultJsonObject).toHaveProperty('locale', 'en');
       expect(reporter.resultJsonObject).toHaveProperty('theme', 'default');
       expect(reporter.resultJsonObject).toHaveProperty('formFactor', '');
@@ -106,7 +106,7 @@ describe.only('TerraWDIOTestDetailsReporter', () => {
     it('sets file name with locale, theme and formFactor', () => {
       const reporter = new TerraWDIOTestDetailsReporter({}, {});
       reporter.fileNameCheck({ locale: 'en', theme: 'default', formFactor: 'tiny' }, '');
-      expect(reporter.fileName).toEqual('result-details-en-default-tiny');
+      expect(reporter.fileName).toEqual('functional-test-details-en-default-tiny');
       expect(reporter.resultJsonObject).toHaveProperty('locale', 'en');
       expect(reporter.resultJsonObject).toHaveProperty('theme', 'default');
       expect(reporter.resultJsonObject).toHaveProperty('formFactor', 'tiny');
@@ -116,7 +116,7 @@ describe.only('TerraWDIOTestDetailsReporter', () => {
     it('sets file name with locale, theme, formFactor and browserName', () => {
       const reporter = new TerraWDIOTestDetailsReporter({}, {});
       reporter.fileNameCheck({ locale: 'en', theme: 'default', formFactor: 'tiny' }, { browserName: 'chrome' });
-      expect(reporter.fileName).toEqual('result-details-en-default-tiny-chrome');
+      expect(reporter.fileName).toEqual('functional-test-details-en-default-tiny-chrome');
       expect(reporter.resultJsonObject).toHaveProperty('locale', 'en');
       expect(reporter.resultJsonObject).toHaveProperty('theme', 'default');
       expect(reporter.resultJsonObject).toHaveProperty('formFactor', 'tiny');


### PR DESCRIPTION
… file name

### Summary
1. added back the TerraWDIOTestDetailsReporter
2. fixed this https://travis-ci.com/github/cerner/terra-core/jobs/487781457 issue in terra-core regarding TerraWDIOTestDetailsReporter 
3. changed the result file names of TerraWDIOTestDetailsReporter form result-details to 3.functional-test-details

Validation pr in terra-core https://github.com/cerner/terra-core/pull/3387
Validation pr in orion-toolkit-js https://github.cerner.com/orion/orion-toolkit-js/pull/117