### PR TITLE
Update TerraWDIOTestDetailsReporter to reset the screenshots array after each test

### DIFF
--- a/docs/TerraWDIOTestDetailsReporter.md
+++ b/docs/TerraWDIOTestDetailsReporter.md
@@ -27,9 +27,9 @@ const TerraWDIOTestDetailsReporter = require('terra-toolkit/reporters/wdio/Terra
 
 ## Report Format
 
-- The name of the log file for non-monorepo will be **result-details-\<locale>-\<theme>-\<form-factor>-\<browser>-\<repo-name>.json**(eg: result-details-en-huge-chrome-terra-toolkit-boneyard.json)
+- The name of the log file for non-monorepo will be **functional-test-details-\<locale>-\<theme>-\<form-factor>-\<browser>-\<repo-name>.json**(eg: functional-test-details-en-huge-chrome-terra-toolkit-boneyard.json)
 
-- The name of the log file for mono-repo will be **result-details-\<Package-name>\<locale>-\<theme>-\<form-factor>-\<browser>.json**(eg: result-details-terra-clinical-data-grid-clinical-lowlight-theme-chrome)
+- The name of the log file for mono-repo will be **functional-test-details-\<Package-name>\<locale>-\<theme>-\<form-factor>-\<browser>.json**(eg: functional-test-details-terra-clinical-data-grid-clinical-lowlight-theme-chrome)
 
-- Example output [a relative link](details-reporter-sample-results.json)
-- Example output when error occurs [a relative link](details-reporter-sample-results-withError.json)
+- Example output [a relative link](functional-test-detailsReporter-sample-results.json)
+- Example output when error occurs [a relative link](functional-test-detailsReporter-sample-results-withError.json)

--- a/docs/functional-test-detailsReporter-sample-results-withError.json
+++ b/docs/functional-test-detailsReporter-sample-results-withError.json
@@ -13,9 +13,7 @@
           {
             "title": "Express correctly sets the application locale",
             "state": "passed",
-            "screenshots": [
-              "/opt/module/tests/wdio/__snapshots__/latest/en/chrome_tiny/i18n-spec/I18n_Locale[default].png"
-            ]
+            "screenshots": []
           },
           {
             "title": "matches screenshot",
@@ -42,9 +40,7 @@
                     "title": "checks element",
                     "state": "passed",
                     "screenshots": [
-                      "/opt/module/tests/wdio/__snapshots__/latest/en/chrome_tiny/validateElement-spec/full_implementation[default].png",
-                      "/opt/module/tests/wdio/__snapshots__/latest/en/chrome_tiny/validateElement-spec/inaccessible_contrast[default].png"
-                    ]
+                      "/opt/module/tests/wdio/__snapshots__/latest/en/chrome_tiny/validateElement-spec/full_implementation[default].png"                    ]
                   }
                 ]
               },
@@ -55,7 +51,6 @@
                     "title": "checks element",
                     "state": "fail",
                     "screenshots": [
-                      "/opt/module/tests/wdio/__snapshots__/latest/en/chrome_tiny/validateElement-spec/full_implementation[default].png",
                       "/opt/module/tests/wdio/__snapshots__/latest/en/chrome_tiny/validateElement-spec/inaccessible_contrast[default].png"
                     ],
                     "error": {

--- a/docs/functional-test-detailsReporter-sample-results.json
+++ b/docs/functional-test-detailsReporter-sample-results.json
@@ -13,9 +13,7 @@
         {
           "title": "Express correctly sets the application locale",
           "state": "passed",
-          "screenshots": [
-            "/opt/module/tests/wdio/__snapshots__/latest/en/chrome_huge/i18n-spec/I18n_Locale[default].png"
-          ]
+          "screenshots": []
         },
         {
           "title": "matches screenshot",
@@ -42,9 +40,7 @@
                   "title": "checks element",
                   "state": "passed",
                   "screenshots": [
-                    "/opt/module/tests/wdio/__snapshots__/latest/en/chrome_huge/validateElement-spec/full_implementation[default].png",
-                    "/opt/module/tests/wdio/__snapshots__/latest/en/chrome_huge/validateElement-spec/inaccessible_contrast[default].png"
-                  ]
+                    "/opt/module/tests/wdio/__snapshots__/latest/en/chrome_huge/validateElement-spec/full_implementation[default].png"                  ]
                 }
               ]
             },
@@ -55,7 +51,6 @@
                   "title": "checks element",
                   "state": "passed",
                   "screenshots": [
-                    "/opt/module/tests/wdio/__snapshots__/latest/en/chrome_huge/validateElement-spec/full_implementation[default].png",
                     "/opt/module/tests/wdio/__snapshots__/latest/en/chrome_huge/validateElement-spec/inaccessible_contrast[default].png"
                   ]
                 }

--- a/reporters/wdio/TerraWDIOTestDetailsReporter.js
+++ b/reporters/wdio/TerraWDIOTestDetailsReporter.js
@@ -163,6 +163,7 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
         });
       }
     }
+    this.screenshots = [];
   }
 
   /**

--- a/tests/jest/TerraWDIOTestDetailsReporter.test.js
+++ b/tests/jest/TerraWDIOTestDetailsReporter.test.js
@@ -248,7 +248,7 @@ describe.only('TerraWDIOTestDetailsReporter', () => {
     it('test:end should reset the screenshots array ', () => {
       const reporter = new TerraWDIOTestDetailsReporter({}, {});
       reporter.emit('test:end', { title: 'title of the it' });
-      expect(reporter.screenshots.length).toBeGreaterThanOrEqual(0);
+      expect(reporter.screenshots.length).toEqual(0);
     });
   });
   describe('runner:end', () => {

--- a/tests/jest/TerraWDIOTestDetailsReporter.test.js
+++ b/tests/jest/TerraWDIOTestDetailsReporter.test.js
@@ -244,6 +244,13 @@ describe.only('TerraWDIOTestDetailsReporter', () => {
       expect(typeof reporter.specHashData[params.specHash][params.title].tests).toEqual('object');
     });
   });
+  describe('test:end', () => {
+    it('test:end should reset the screenshots array ', () => {
+      const reporter = new TerraWDIOTestDetailsReporter({}, {});
+      reporter.emit('test:end', { title: 'title of the it' });
+      expect(reporter.screenshots.length).toBeGreaterThanOrEqual(0);
+    });
+  });
   describe('runner:end', () => {
     it('suite:start for mono repo', () => {
       const reporter = new TerraWDIOTestDetailsReporter({}, {});

--- a/tests/jest/TerraWDIOTestDetailsReporter.test.js
+++ b/tests/jest/TerraWDIOTestDetailsReporter.test.js
@@ -247,6 +247,7 @@ describe.only('TerraWDIOTestDetailsReporter', () => {
   describe('test:end', () => {
     it('test:end should reset the screenshots array ', () => {
       const reporter = new TerraWDIOTestDetailsReporter({}, {});
+      reporter.screenshots = ['/opt/module/tests/wdio/__snapshots__/latest/fr/chrome_huge/i18n-spec/I18n_Locale[default].png'];
       reporter.emit('test:end', { title: 'title of the it' });
       expect(reporter.screenshots.length).toEqual(0);
     });


### PR DESCRIPTION
### Summary
Small fix to reset the screenshots array after every test

Also updated the docs for the TerraWDIOTestDetailsReporter to reflect the changes we made to the result file where file name should start with functional-test-details and also updated the sample results structure of the TerraWDIOTestDetailsReporter