### PR TITLE
Update TerraWDIOTestDetailsReporter to create separate objects for different viewports mentioned in the describeViewports

### DIFF
--- a/reporters/wdio/TerraWDIOTestDetailsReporter.js
+++ b/reporters/wdio/TerraWDIOTestDetailsReporter.js
@@ -139,10 +139,12 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
     const {
       specHash, fullTitle, title,
     } = test;
-    const { specHashData, moduleName, title, state, screenshots } = this;
+    const { specHashData, moduleName, state } = this;
+    let { screenshots } = this;
+
     const specParent = fullTitle.replace(` ${title}`, '');
     const testInfo = {
-      title,
+      title: this.title,
       state,
       screenshots,
     };

--- a/reporters/wdio/TerraWDIOTestDetailsReporter.js
+++ b/reporters/wdio/TerraWDIOTestDetailsReporter.js
@@ -139,14 +139,14 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
     const {
       specHash, fullTitle, title,
     } = test;
-    const { specHashData, moduleName } = this;
+    const { specHashData, moduleName, title, state, screenshots } = this;
     const specParent = fullTitle.replace(` ${title}`, '');
     const testInfo = {
-      title: this.title,
-      state: this.state,
-      screenshots: this.screenshots,
+      title,
+      state,
+      screenshots,
     };
-    if (this.state === 'fail') {
+    if (state === 'fail') {
       testInfo.error = this.error;
     }
     if (
@@ -159,7 +159,7 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
     } else if (specHashData[specHash] && specHashData[specHash][specParent]) {
       specHashData[specHash][specParent].tests.push(testInfo);
     }
-    this.screenshots = [];
+    screenshots = [];
   }
 
   /**

--- a/reporters/wdio/TerraWDIOTestDetailsReporter.js
+++ b/reporters/wdio/TerraWDIOTestDetailsReporter.js
@@ -139,7 +139,9 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
     const {
       specHash, fullTitle, title,
     } = test;
-    const { specHashData, moduleName, state, title: testTitle } = this;
+    const {
+      specHashData, moduleName, state, title: testTitle,
+    } = this;
     let { screenshots } = this;
 
     const specParent = fullTitle.replace(` ${title}`, '');

--- a/reporters/wdio/TerraWDIOTestDetailsReporter.js
+++ b/reporters/wdio/TerraWDIOTestDetailsReporter.js
@@ -56,7 +56,9 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
   }
 
   latestScreenshot(screenshotPath) {
-    if (!this.screenshots.includes(screenshotPath.screenshotPath)) this.screenshots.push(screenshotPath.screenshotPath);
+    if (!this.screenshots.includes(screenshotPath.screenshotPath)) {
+      this.screenshots.push(screenshotPath.screenshotPath);
+    }
   }
 
   runnerStart(runner) {

--- a/reporters/wdio/TerraWDIOTestDetailsReporter.js
+++ b/reporters/wdio/TerraWDIOTestDetailsReporter.js
@@ -139,12 +139,12 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
     const {
       specHash, fullTitle, title,
     } = test;
-    const { specHashData, moduleName, state } = this;
+    const { specHashData, moduleName, state, title: testTitle } = this;
     let { screenshots } = this;
 
     const specParent = fullTitle.replace(` ${title}`, '');
     const testInfo = {
-      title: this.title,
+      title: testTitle,
       state,
       screenshots,
     };

--- a/reporters/wdio/TerraWDIOTestDetailsReporter.js
+++ b/reporters/wdio/TerraWDIOTestDetailsReporter.js
@@ -142,13 +142,11 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
     const {
       specHashData, moduleName, state, title: testTitle,
     } = this;
-    let { screenshots } = this;
-
     const specParent = fullTitle.replace(` ${title}`, '');
     const testInfo = {
       title: testTitle,
       state,
-      screenshots,
+      screenshots: this.screenshots,
     };
     if (state === 'fail') {
       testInfo.error = this.error;
@@ -163,7 +161,7 @@ class TerraWDIOTestDetailsReporter extends events.EventEmitter {
     } else if (specHashData[specHash] && specHashData[specHash][specParent]) {
       specHashData[specHash][specParent].tests.push(testInfo);
     }
-    screenshots = [];
+    this.screenshots = [];
   }
 
   /**

--- a/tests/jest/TerraWDIOTestDetailsReporter.test.js
+++ b/tests/jest/TerraWDIOTestDetailsReporter.test.js
@@ -262,7 +262,7 @@ describe.only('TerraWDIOTestDetailsReporter', () => {
     it('test:end should reset the screenshots array ', () => {
       const reporter = new TerraWDIOTestDetailsReporter({}, {});
       reporter.screenshots = ['/opt/module/tests/wdio/__snapshots__/latest/fr/chrome_huge/i18n-spec/I18n_Locale[default].png'];
-      reporter.emit('test:end', { title: 'title of the it', fullTitle: 'parent title of the it' });
+      reporter.emit('test:end', { title: 'Express correctly sets the application locale', fullTitle: 'I18n Locale Express correctly sets the application locale' });
       expect(reporter.screenshots.length).toEqual(0);
     });
   });

--- a/tests/jest/TerraWDIOTestDetailsReporter.test.js
+++ b/tests/jest/TerraWDIOTestDetailsReporter.test.js
@@ -220,14 +220,21 @@ describe.only('TerraWDIOTestDetailsReporter', () => {
         specHash: 'f75728c9953420794e669cae74b03d58',
         title: 'group2',
         parent: 'hideInputCaret',
+        cid: '1-0',
+        runner: {
+          '1-0': {
+            browserName: 'chrome',
+          },
+        },
+
       };
       reporter.moduleName = 'terra-clinical';
       reporter.emit('suite:start', params);
       expect(reporter.specHashData).toHaveProperty(reporter.moduleName);
-      expect(reporter.specHashData[reporter.moduleName][params.specHash][params.title]).toHaveProperty('parent');
-      expect(reporter.specHashData[reporter.moduleName][params.specHash][params.title]).toHaveProperty('title');
-      expect(reporter.specHashData[reporter.moduleName][params.specHash][params.title]).toHaveProperty('tests');
-      expect(typeof reporter.specHashData[reporter.moduleName][params.specHash][params.title].tests).toEqual('object');
+      expect(reporter.specHashData[reporter.moduleName][params.specHash][params.fullTitle]).toHaveProperty('parent');
+      expect(reporter.specHashData[reporter.moduleName][params.specHash][params.fullTitle]).toHaveProperty('title');
+      expect(reporter.specHashData[reporter.moduleName][params.specHash][params.fullTitle]).toHaveProperty('tests');
+      expect(typeof reporter.specHashData[reporter.moduleName][params.specHash][params.fullTitle].tests).toEqual('object');
     });
     it('suite:start for non mono repo', () => {
       const reporter = new TerraWDIOTestDetailsReporter({}, {});
@@ -235,25 +242,32 @@ describe.only('TerraWDIOTestDetailsReporter', () => {
         specHash: 'f75728c9953420794e669cae74b03d58',
         title: 'group2',
         parent: 'hideInputCaret',
+        cid: '1-0',
+        runner: {
+          '1-0': {
+            browserName: 'chrome',
+          },
+        },
+
       };
       reporter.emit('suite:start', params);
       expect(reporter.specHashData).not.toHaveProperty(reporter.moduleName);
-      expect(reporter.specHashData[params.specHash][params.title]).toHaveProperty('parent');
-      expect(reporter.specHashData[params.specHash][params.title]).toHaveProperty('title');
-      expect(reporter.specHashData[params.specHash][params.title]).toHaveProperty('tests');
-      expect(typeof reporter.specHashData[params.specHash][params.title].tests).toEqual('object');
+      expect(reporter.specHashData[params.specHash][params.fullTitle]).toHaveProperty('parent');
+      expect(reporter.specHashData[params.specHash][params.fullTitle]).toHaveProperty('title');
+      expect(reporter.specHashData[params.specHash][params.fullTitle]).toHaveProperty('tests');
+      expect(typeof reporter.specHashData[params.specHash][params.fullTitle].tests).toEqual('object');
     });
   });
   describe('test:end', () => {
     it('test:end should reset the screenshots array ', () => {
       const reporter = new TerraWDIOTestDetailsReporter({}, {});
       reporter.screenshots = ['/opt/module/tests/wdio/__snapshots__/latest/fr/chrome_huge/i18n-spec/I18n_Locale[default].png'];
-      reporter.emit('test:end', { title: 'title of the it' });
+      reporter.emit('test:end', { title: 'title of the it', fullTitle: 'parent title of the it' });
       expect(reporter.screenshots.length).toEqual(0);
     });
   });
   describe('runner:end', () => {
-    it('suite:start for mono repo', () => {
+    it('runner:end for mono repo', () => {
       const reporter = new TerraWDIOTestDetailsReporter({}, {});
       reporter.specHashData = {
         'terra-clinical-data-grid':
@@ -292,21 +306,33 @@ describe.only('TerraWDIOTestDetailsReporter', () => {
       reporter.emit('runner:end', runner);
       expect(reporter.resultJsonObject).toHaveProperty('specs');
       expect(typeof reporter.resultJsonObject).toEqual('object');
-      expect(reporter.resultJsonObject.specs[reporter.moduleName].tests.length).toBeGreaterThanOrEqual(1);
+      expect(reporter.resultJsonObject.specs[reporter.moduleName][0].tests.length).toBeGreaterThanOrEqual(1);
       expect(fs.writeFileSync).toHaveBeenCalled();
     });
-    it('suite:start for non mono repo', () => {
+    it('runner:end for non mono repo', () => {
       const reporter = new TerraWDIOTestDetailsReporter({}, {});
       reporter.specHashData = {
         f75728c9953420794e669cae74b03d58: {
           hideInputCaret: {
             parent: 'hideInputCaret',
             title: 'hideInputCaret',
-            tests: [],
+            browser: 'chrome',
+            tests: [
+              {
+                title: 'Express correctly sets the application locale',
+                state: 'passed',
+              },
+              {
+                title: '[default] to be within the mismatch tolerance',
+                state: 'passed',
+                screenshotLink: '/opt/module/tests/wdio/__snapshots__/latest/fr/chrome_huge/i18n-spec/I18n_Locale[default].png',
+              },
+            ],
           },
           group1: {
             parent: 'hideInputCaret',
             title: 'group1',
+            browser: 'chrome',
             tests: [
               {
                 title: "validates the textarea's caret-color is inherited as transparent",
@@ -320,10 +346,11 @@ describe.only('TerraWDIOTestDetailsReporter', () => {
       const runner = {
         event: 'runner:end',
         failures: 0,
-        cid: '0-2',
+        cid: '1-0',
         specs: ['/opt/module/tests/wdio/hideInputCaret-spec.js'],
         specHash: 'f75728c9953420794e669cae74b03d58',
       };
+      reporter.resultJsonObject.capabilities.browserName = 'chrome';
       reporter.emit('runner:end', runner);
       expect(reporter.resultJsonObject).toHaveProperty('specs');
       expect(typeof reporter.resultJsonObject).toEqual('object');


### PR DESCRIPTION
### Summary
In TerraWDIOTestDetailsReporter when two view ports are mentioned in the describeViewports all the tests are included in the first viewport mentioned in the describeViewports instead of creating two separate options for two view ports

Closes https://github.com/cerner/terra-toolkit-boneyard/issues/96

### Additional Details
1. Here's is an example from orion application of what's happening vs. what we would expect https://gist.github.cerner.com/RM012685/108fe5f8dde123fb623e43b0970a7e56
2. And also in some case when tests run for two browser, the tests should be in separate files for each browser but it is not happening right now

All the above issues are addressed in this pr
