### PR TITLE
[WDIO] Allow global.browsers to pause for all  browsers and add log for browser timeout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated `global.browser` to pause for all browsers.
+
 ## 6.15.0 - (April 23, 2021)
 
 * Fixed

--- a/src/wdio/services/TerraCommands/viewport-helpers.js
+++ b/src/wdio/services/TerraCommands/viewport-helpers.js
@@ -23,16 +23,20 @@ const getViewports = (...sizes) => {
 * @param {string} [formFactor=huge] - the Terra test viewport.
 */
 const setViewport = (formFactor) => {
-  if (formFactor) {
-    const terraViewport = VIEWPORTS[formFactor];
-    if (terraViewport !== undefined && typeof terraViewport === 'object') {
-      global.browser.setViewportSize(terraViewport);
+  if (global.browser.setViewportSize) {
+    if (formFactor) {
+      const terraViewport = VIEWPORTS[formFactor];
+      if (terraViewport !== undefined && typeof terraViewport === 'object') {
+        global.browser.setViewportSize(terraViewport);
+      } else {
+        throw Logger.error('The formFactor supplied is not a Terra-defined viewport size.', { context: '[Terra-Toolkit:terra-service]' });
+      }
     } else {
-      throw Logger.error('The formFactor supplied is not a Terra-defined viewport size.', { context: '[Terra-Toolkit:terra-service]' });
+      const defaultViewport = VIEWPORTS.huge;
+      global.browser.setViewportSize(defaultViewport);
     }
   } else {
-    const defaultViewport = VIEWPORTS.huge;
-    global.browser.setViewportSize(defaultViewport);
+    throw Logger.log('Browser Timeout', { context: '[Terra-Toolkit:terra-service]' });
   }
 };
 

--- a/src/wdio/services/TerraCommands/viewport-helpers.js
+++ b/src/wdio/services/TerraCommands/viewport-helpers.js
@@ -36,7 +36,7 @@ const setViewport = (formFactor) => {
       global.browser.setViewportSize(defaultViewport);
     }
   } else {
-    throw Logger.log('Browser Timeout', { context: '[Terra-Toolkit:terra-service]' });
+    throw Logger.log('Browser Timeout after 10000ms', { context: '[Terra-Toolkit:terra-service]' });
   }
 };
 

--- a/src/wdio/services/TerraService.js
+++ b/src/wdio/services/TerraService.js
@@ -21,7 +21,7 @@ export default class TerraService {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  before(capabilities) {
+  before() {
     /* Add Terra's custom Wdio command for a11y testing. */
     global.browser.addCommand('axe', axeCommand);
 
@@ -64,10 +64,7 @@ export default class TerraService {
       },
     };
 
-    /* IE driver takes a longer to be ready for browser interactions. */
-    if (capabilities.browserName === 'internet explorer') {
-      global.browser.pause(10000);
-    }
+    global.browser.pause(10000);
 
     /* Set the viewport size before the spec begins.  */
     viewportHelpers.setViewport(global.browser.options.formFactor);


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->
This PR removes the `if` condition before `global.browser.pause(10000)` to allow waiting for all the browsers and adds log if `global.browser.setViewportSize` is still unavailable.

closes #91 #92 

### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/main/CONTRIBUTORS.md
[License]: ../blob/main/LICENSE
